### PR TITLE
app: collapsing demo: Use padding instead of margin for text

### DIFF
--- a/app/src/main/res/layout/activity_collapsing.xml
+++ b/app/src/main/res/layout/activity_collapsing.xml
@@ -51,7 +51,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_margin="16dp"
+            android:padding="16dp"
             android:orientation="vertical">
 
             <TextView


### PR DESCRIPTION
NestedScrollView has a where it doesn't measure the nested child bottom
margin and ends up cutting text. Use padding as a workaround.

Fixes #8