### PR TITLE
add hasToolbar attribute

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,10 @@ buildscript {
     repositories {
         maven { url 'https://maven.google.com' }
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.4.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Sep 30 14:01:47 EEST 2017
+#Mon May 06 18:54:08 WAT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/scalinglib/src/main/java/iammert/com/view/scalinglib/ScalingLayout.java
+++ b/scalinglib/src/main/java/iammert/com/view/scalinglib/ScalingLayout.java
@@ -355,6 +355,10 @@ public class ScalingLayout extends FrameLayout {
         }
     }
 
+    public boolean hasToolbar() {
+        return settings.hasToolbar();
+    }
+
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Override
     public ViewOutlineProvider getOutlineProvider() {

--- a/scalinglib/src/main/java/iammert/com/view/scalinglib/ScalingLayoutBehavior.java
+++ b/scalinglib/src/main/java/iammert/com/view/scalinglib/ScalingLayoutBehavior.java
@@ -12,11 +12,9 @@ import android.view.View;
 
 public class ScalingLayoutBehavior extends CoordinatorLayout.Behavior<ScalingLayout> {
 
-    private final float toolbarHeightInPixel;
 
     public ScalingLayoutBehavior(Context context, AttributeSet attrs) {
         super(context, attrs);
-        toolbarHeightInPixel = context.getResources().getDimensionPixelSize(R.dimen.sl_toolbar_size);
     }
 
     @Override
@@ -27,6 +25,10 @@ public class ScalingLayoutBehavior extends CoordinatorLayout.Behavior<ScalingLay
     @Override
     public boolean onDependentViewChanged(CoordinatorLayout parent, ScalingLayout child, View dependency) {
         int totalScrollRange = ((AppBarLayout) dependency).getTotalScrollRange();
+        int toolbarHeightInPixel ;
+        if(child.hasToolbar()) toolbarHeightInPixel = parent.getContext().getResources().getDimensionPixelSize(R.dimen.sl_toolbar_size);
+        else toolbarHeightInPixel = 0 ;
+
         child.setProgress((-dependency.getY()) / totalScrollRange);
         if (totalScrollRange + dependency.getY() > (float) child.getMeasuredHeight() / 2) {
             child.setTranslationY(totalScrollRange + dependency.getY() + toolbarHeightInPixel - (float) child.getMeasuredHeight() / 2);

--- a/scalinglib/src/main/java/iammert/com/view/scalinglib/ScalingLayoutSettings.java
+++ b/scalinglib/src/main/java/iammert/com/view/scalinglib/ScalingLayoutSettings.java
@@ -18,10 +18,12 @@ public class ScalingLayoutSettings {
     private float maxRadius;
     private float elevation;
     private boolean isInitialized = false;
+    private boolean hasToolbar ;
 
     public ScalingLayoutSettings(Context context, AttributeSet attributeSet) {
         TypedArray typedArray = context.obtainStyledAttributes(attributeSet, R.styleable.ScalingLayout);
         radiusFactor = typedArray.getFloat(R.styleable.ScalingLayout_radiusFactor, DEFAULT_RADIUS_FACTOR);
+        hasToolbar = typedArray.getBoolean(R.styleable.ScalingLayout_hasToolbar,false);
         maxWidth = context.getResources().getDisplayMetrics().widthPixels;
         typedArray.recycle();
 
@@ -61,5 +63,9 @@ public class ScalingLayoutSettings {
 
     public float getElevation() {
         return elevation;
+    }
+
+    public boolean hasToolbar() {
+        return hasToolbar;
     }
 }

--- a/scalinglib/src/main/res/values/attrs.xml
+++ b/scalinglib/src/main/res/values/attrs.xml
@@ -3,6 +3,7 @@
 
     <declare-styleable name="ScalingLayout">
         <attr name="radiusFactor" format="float"/>
+        <attr name="hasToolbar" format="boolean"/>
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
when not using toolbar it keeps size of toolbar(56dp) between AppbarLayout and ScalingLayout

As shown in the picture
![Screenshot_20190506-172232](https://user-images.githubusercontent.com/38055325/57247559-1851bc00-7038-11e9-97a8-be1fd1eabaa0.png)

so i simply added an attribute hasToolbar to set if there is toolbar or not 